### PR TITLE
chore: add release 6.{1,2}

### DIFF
--- a/.github/workflows/fdb-release.yml
+++ b/.github/workflows/fdb-release.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        branch: ["release-7.0", "release-6.3", "release-6.2", "release-6.1"]
+        branch: ["release-7.0", "release-6.3", "release-6.2"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/fdb-release.yml
+++ b/.github/workflows/fdb-release.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        branch: ["release-7.0", "release-6.3"]
+        branch: ["release-7.0", "release-6.3", "release-6.2", "release-6.1"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
FoundationDB's website is down for more than a week now, most CI cannot download any new release. This might help, even if I'm not sure if building such old releases will work out-of-the-box